### PR TITLE
Remove redundant build flags

### DIFF
--- a/org.gajim.Gajim.yaml
+++ b/org.gajim.Gajim.yaml
@@ -31,10 +31,6 @@ add-extensions:
     no-autodownload: true
     autodelete: true
 
-build-options:
-  cflags: -O2 -g
-  cxxflags: -O2 -g
-
 cleanup:
   - '/bin/easy*'
   - /include


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.